### PR TITLE
Clarify mirror setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ docker pull yourdomain.com/ghcr.io/sky22333/hubproxy
 # 符合Docker Registry API v2标准的仓库都支持
 ```
 
+也可以在 Docker 的 `daemon.json` 中配置本服务作为镜像加速器。编辑（或创建） `/etc/docker/daemon.json`，添加如下内容：
+
+```json
+{
+  "registry-mirrors": [
+    "https://yourdomain.com"
+  ]
+}
+```
+
+修改后重启 Docker 即可生效。
+
 ### GitHub 文件加速
 
 ```bash

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -688,6 +688,17 @@
                 <strong>K8s 镜像：</strong>
                 docker pull <span class="domain-base"></span>/registry.k8s.io/pause:3.8
             </div>
+
+            <div class="domain-examples">
+                <strong>daemon.json 设置步骤：</strong>
+                在 Docker 主机上编辑 <code>/etc/docker/daemon.json</code>（若文件不存在请新建），填入以下内容：<br>
+                {<br>
+                &nbsp;&nbsp;"registry-mirrors": [<br>
+                &nbsp;&nbsp;&nbsp;&nbsp;"https://<span class="domain-base"></span>"<br>
+                &nbsp;&nbsp;]<br>
+                }<br>
+                保存后重启 Docker（例如执行 <code>sudo systemctl restart docker</code>）即可生效。
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- clarify daemon.json mirror configuration in README
- expand mirror instructions in the homepage modal

## Testing
- `go build ./...` *(fails: proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68773c59d6c48327b79ef7244b1bb17b