### PR TITLE
Add registry mirror usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ docker pull yourdomain.com/ghcr.io/sky22333/hubproxy
 # 符合Docker Registry API v2标准的仓库都支持
 ```
 
+还可以把服务作为 Docker 的镜像加速器使用。
+在主机上编辑（或新建）`/etc/docker/daemon.json`，
+在 `"registry-mirrors"` 中加入域名：
+
+```json
+{
+  "registry-mirrors": [
+    "https://yourdomain.com"
+  ]
+}
+```
+
+若已设置其他加速地址，直接并列添加后保存，
+再执行 `sudo systemctl restart docker` 让配置生效。
+
 ### GitHub 文件加速
 
 ```bash


### PR DESCRIPTION
## Summary
- explain how to use hubproxy as a Docker `registry-mirrors` accelerator in the docs

## Testing
- `go vet ./...` *(fails: access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68778d023f248327b02f492034390a13